### PR TITLE
fix the build and start using travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: c
+sudo: false
+services:
+  - docker
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-docker.sh
+script: bash -ex ./.travis-docker.sh
+env:
+  global:
+  - DISTRO="ubuntu"
+  - PACKAGE="websocketaf"
+  - TESTS=true
+  matrix:
+  - OCAML_VERSION="4.07"
+  - OCAML_VERSION="4.06"
+  - OCAML_VERSION="4.05"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # websocketaf
 
+[![Build Status](https://travis-ci.org/inhabitedtype/websocketaf.svg?branch=master)](https://travis-ci.org/inhabitedtype/websocketaf)
+
 WIP

--- a/lib/client_connection.ml
+++ b/lib/client_connection.ml
@@ -1,3 +1,5 @@
+module IOVec = Httpaf.IOVec
+
 type state =
   | Uninitialized
   | Handshake of Client_handshake.t
@@ -5,11 +7,19 @@ type state =
 
 type t = state ref
 
+type error =
+  [ Httpaf.Client_connection.error
+  | `Handshake_failure of Httpaf.Response.t * [`read] Httpaf.Body.t ]
+
+type input_handlers = Client_websocket.input_handlers =
+  { frame : opcode:Websocket.Opcode.t -> is_fin:bool -> Bigstringaf.t -> off:int -> len:int -> unit
+  ; eof   : unit                                                                            -> unit }
+
 let passes_scrutiny ~accept headers =
   let upgrade              = Httpaf.Headers.get headers "upgrade"    in
   let connection           = Httpaf.Headers.get headers "connection" in
   let sec_websocket_accept = Httpaf.Headers.get headers "sec-websocket-accept" in
-  sec_websocket_accept = accept
+  sec_websocket_accept = Some accept
   && (match upgrade with
      | None         -> false
      | Some upgrade -> String.lowercase_ascii upgrade = "websocket")
@@ -18,26 +28,36 @@ let passes_scrutiny ~accept headers =
      | Some connection -> String.lowercase_ascii connection = "upgrade")
 ;;
 
-let create 
-    ~nonce 
-    ~host 
-    ~port 
+let handshake_exn t =
+  match !t with
+  | Handshake handshake -> handshake
+  | Uninitialized
+  | Websocket _ -> assert false
+
+let create
+    ~nonce
+    ~host
+    ~port
     ~resource
     ~sha1
     ~error_handler
     ~websocket_handler
   =
   let t = ref Uninitialized in
+  let nonce = B64.encode nonce in
   let response_handler response response_body =
     let accept = sha1 (nonce ^ "258EAFA5-E914-47DA-95CA-C5AB0DC85B11") in
-    match response.code with
+    match response.Httpaf.Response.status with
     | `Switching_protocols when passes_scrutiny ~accept response.headers ->
-      Body.close response_body response_body;
-      t := Websocket (Client_websocket.create ~websocket_handler ~eof_handler)
+      Httpaf.Body.close_reader response_body;
+      let handshake = handshake_exn t in
+      t := Websocket (Client_websocket.create ~websocket_handler);
+      Client_handshake.close handshake
     | _                    ->
       error_handler (`Handshake_failure(response, response_body))
   in
-  let handshake = 
+  let handshake =
+    let error_handler = (error_handler :> Httpaf.Client_connection.error_handler) in
     Client_handshake.create
       ~nonce
       ~host
@@ -64,18 +84,11 @@ let read t bs ~off ~len =
   | Websocket websocket -> Client_websocket.read websocket bs ~off ~len
 ;;
 
-let yield_reader t f =
+let read_eof t bs ~off ~len =
   match !t with
   | Uninitialized       -> assert false
-  | Handshake handshake -> Client_handshake.yield_reader handshake f 
-  | Websocket websocket -> Client_websocket.yield_reader websocket f 
-;;
-
-let shutdown_reader t =
-  match !t with
-  | Uninitialized       -> assert false
-  | Handshake handshake -> Client_handshake.shutdown_reader handshake
-  | Websocket websocket -> Client_websocket.shutdown_reader websocket
+  | Handshake handshake -> Client_handshake.read handshake bs ~off ~len
+  | Websocket websocket -> Client_websocket.read_eof websocket bs ~off ~len
 ;;
 
 let next_write_operation t =
@@ -95,13 +108,13 @@ let report_write_result t result =
 let yield_writer t f =
   match !t with
   | Uninitialized       -> assert false
-  | Handshake handshake -> Client_handshake.yield_writer handshake f 
-  | Websocket websocket -> Client_websocket.yield_writer websocket f 
+  | Handshake handshake -> Client_handshake.yield_writer handshake f
+  | Websocket websocket -> Client_websocket.yield_writer websocket f
 ;;
 
 let close t =
   match !t with
   | Uninitialized       -> assert false
-  | Handshake handshake -> Client_handshake.close handshake f 
-  | Websocket websocket -> Client_websocket.close websocket f 
+  | Handshake handshake -> Client_handshake.close handshake
+  | Websocket websocket -> Client_websocket.close websocket
 ;;

--- a/lib/client_connection.ml
+++ b/lib/client_connection.ml
@@ -44,7 +44,7 @@ let create
     ~websocket_handler
   =
   let t = ref Uninitialized in
-  let nonce = B64.encode nonce in
+  let nonce = Base64.encode_exn nonce in
   let response_handler response response_body =
     let accept = sha1 (nonce ^ "258EAFA5-E914-47DA-95CA-C5AB0DC85B11") in
     match response.Httpaf.Response.status with

--- a/lib/client_connection.mli
+++ b/lib/client_connection.mli
@@ -1,32 +1,33 @@
 module IOVec = Httpaf.IOVec
 
-type t 
+type t
 
 type error =
   [ Httpaf.Client_connection.error
-  | `Handshake_failure of Httpaf.Request.t * [`read] Httpaf.Body.t ]
+  | `Handshake_failure of Httpaf.Response.t * [`read] Httpaf.Body.t ]
 
-type input_handlers = Client_websocket.input_handlers = 
-  { frame : Websocket.Opcode.t -> is_fin:bool -> Bigstringaf.t -> off:int -> len:int -> unit
-  ; eof   : unit                                                                   -> unit }
+type input_handlers = Client_websocket.input_handlers =
+  { frame : opcode:Websocket.Opcode.t -> is_fin:bool -> Bigstringaf.t -> off:int -> len:int -> unit
+  ; eof   : unit                                                                            -> unit }
 
-val create 
+val create
   :  nonce             : string
   -> host              : string
   -> port              : int
   -> resource          : string
   -> sha1              : (string -> string)
-  -> error_handler     : (Httpaf.Response.t -> [`read] Httpaf.Body.t -> unit)
-  -> websocket_handler : (Wsd.t                                      -> input_handlers)
+  -> error_handler     : (error -> unit)
+  -> websocket_handler : (Wsd.t -> input_handlers)
   -> t
 
-val next_read_operation  : t -> [ `Read | `Yield | `Close ]
+val next_read_operation  : t -> [ `Read | `Close ]
 val next_write_operation : t -> [ `Write of Bigstringaf.t IOVec.t list | `Yield | `Close of int ]
 
 val read : t -> Bigstringaf.t -> off:int -> len:int -> int
+val read_eof : t -> Bigstringaf.t -> off:int -> len:int -> int
+
 val report_write_result : t -> [`Ok of int | `Closed ] -> unit
 
-val yield_reader : t -> (unit -> unit) -> unit
 val yield_writer : t -> (unit -> unit) -> unit
 
 val close : t -> unit

--- a/lib/client_connection.mli
+++ b/lib/client_connection.mli
@@ -7,7 +7,7 @@ type error =
   | `Handshake_failure of Httpaf.Request.t * [`read] Httpaf.Body.t ]
 
 type input_handlers = Client_websocket.input_handlers = 
-  { frame : Websocket.Opcode.t -> is_fin:bool -> Bigstring.t -> off:int -> len:int -> unit
+  { frame : Websocket.Opcode.t -> is_fin:bool -> Bigstringaf.t -> off:int -> len:int -> unit
   ; eof   : unit                                                                   -> unit }
 
 val create 
@@ -21,9 +21,9 @@ val create
   -> t
 
 val next_read_operation  : t -> [ `Read | `Yield | `Close ]
-val next_write_operation : t -> [ `Write of Bigstring.t IOVec.t list | `Yield | `Close of int ]
+val next_write_operation : t -> [ `Write of Bigstringaf.t IOVec.t list | `Yield | `Close of int ]
 
-val read : t -> Bigstring.t -> off:int -> len:int -> int
+val read : t -> Bigstringaf.t -> off:int -> len:int -> int
 val report_write_result : t -> [`Ok of int | `Closed ] -> unit
 
 val yield_reader : t -> (unit -> unit) -> unit

--- a/lib/client_handshake.ml
+++ b/lib/client_handshake.ml
@@ -1,29 +1,50 @@
 module IOVec = Httpaf.IOVec
-include Httpaf.Client_connection
 
-let create 
-    ~nonce 
-    ~host 
-    ~port 
+type t =
+  { connection : Httpaf.Client_connection.t
+  ; body       : [`write] Httpaf.Body.t }
+
+let create
+    ~nonce
+    ~host
+    ~port
     ~resource
     ~error_handler
-    ~response_handler 
+    ~response_handler
   =
-  let nonce = Base64.encode_exn nonce in
   let headers =
     [ "upgrade"              , "websocket"
     ; "connection"           , "upgrade"
     ; "host"                 , String.concat ":" [ host; string_of_int port ]
-    ; "sec-websocket-version", "13" 
+    ; "sec-websocket-version", "13"
     ; "sec-websocket-key"    , nonce
     ] |> Httpaf.Headers.of_list
   in
-  let request_body, t =
+  let body, connection =
     Httpaf.Client_connection.request
       (Httpaf.Request.create ~headers `GET resource)
       ~error_handler
       ~response_handler
   in
-  Httpaf.Body.close_writer request_body;
-  t
+  { connection
+  ; body
+  }
 ;;
+
+let next_read_operation t =
+  Httpaf.Client_connection.next_read_operation t.connection
+
+let next_write_operation t =
+  Httpaf.Client_connection.next_write_operation t.connection
+
+let read t =
+  Httpaf.Client_connection.read t.connection
+
+let report_write_result t =
+  Httpaf.Client_connection.report_write_result t.connection
+
+let yield_writer t =
+  Httpaf.Client_connection.yield_writer t.connection
+
+let close t =
+  Httpaf.Body.close_writer t.body

--- a/lib/client_handshake.mli
+++ b/lib/client_handshake.mli
@@ -1,8 +1,8 @@
 module IOVec = Httpaf.IOVec
 
-type t 
+type t
 
-val create 
+val create
   :  nonce            : string
   -> host             : string
   -> port             : int
@@ -15,7 +15,8 @@ val next_read_operation  : t -> [ `Read | `Close ]
 val next_write_operation : t -> [ `Write of Bigstringaf.t IOVec.t list | `Yield | `Close of int ]
 
 val read : t -> Bigstringaf.t -> off:int -> len:int -> int
-val shutdown_reader : t -> unit
 val report_write_result : t -> [`Ok of int | `Closed ] -> unit
 
 val yield_writer : t -> (unit -> unit) -> unit
+
+val close : t -> unit

--- a/lib/client_websocket.ml
+++ b/lib/client_websocket.ml
@@ -1,14 +1,46 @@
+module IOVec = Httpaf.IOVec
+
 type t =
-  { reader : Reader.t
+  { reader : [`Parse of string list * string] Reader.t
   ; wsd    : Wsd.t }
 
 type input_handlers =
-  { frame : Websocket.Opcode.t -> is_fin:bool -> Bigstringaf.t -> off:int -> len:int -> unit
-  ; eof   : unit                                                                   -> unit }
+  { frame : opcode:Websocket.Opcode.t -> is_fin:bool -> Bigstringaf.t -> off:int -> len:int -> unit
+  ; eof   : unit                                                                            -> unit }
+
+let random_int32 () =
+  Random.int32 Int32.max_int
 
 let create ~websocket_handler =
-  let wsd            = Wsd.create () in
-  let { frame; eof } = websocket_handler wsd in
+  let mode         = `Client random_int32 in
+  let wsd          = Wsd.create mode in
+  let { frame; _ } = websocket_handler wsd in
   { reader = Reader.create frame
-  ; wds 
+  ; wsd
   }
+
+let next_read_operation t =
+  Reader.next t.reader
+
+let next_write_operation t =
+  Wsd.next t.wsd
+
+let read t bs ~off ~len =
+  Reader.read_with_more t.reader bs ~off ~len Incomplete
+
+let read_eof t bs ~off ~len =
+  Reader.read_with_more t.reader bs ~off ~len Complete
+
+let report_write_result t result =
+  Wsd.report_result t.wsd result
+
+let yield_writer t k =
+  if Wsd.is_closed t.wsd
+  then begin
+    Wsd.close t.wsd;
+    k ()
+  end else
+    Wsd.when_ready_to_write t.wsd k
+
+let close { wsd; _ } =
+  Wsd.close wsd

--- a/lib/client_websocket.ml
+++ b/lib/client_websocket.ml
@@ -3,7 +3,7 @@ type t =
   ; wsd    : Wsd.t }
 
 type input_handlers =
-  { frame : Websocket.Opcode.t -> is_fin:bool -> Bigstring.t -> off:int -> len:int -> unit
+  { frame : Websocket.Opcode.t -> is_fin:bool -> Bigstringaf.t -> off:int -> len:int -> unit
   ; eof   : unit                                                                   -> unit }
 
 let create ~websocket_handler =

--- a/lib/client_websocket.mli
+++ b/lib/client_websocket.mli
@@ -3,7 +3,7 @@ module IOVec = Httpaf.IOVec
 type t
 
 type input_handlers =
-  { frame : Websocket.Opcode.t -> is_fin:bool -> Bigstring.t -> off:int -> len:int -> unit
+  { frame : Websocket.Opcode.t -> is_fin:bool -> Bigstringaf.t -> off:int -> len:int -> unit
   ; eof   : unit                                                                   -> unit }
 
 val create 
@@ -11,9 +11,9 @@ val create
   -> t
 
 val next_read_operation  : t -> [ `Read | `Yield | `Close ]
-val next_write_operation : t -> [ `Write of Bigstring.t IOVec.t list | `Yield | `Close of int ]
+val next_write_operation : t -> [ `Write of Bigstringaf.t IOVec.t list | `Yield | `Close of int ]
 
-val read : t -> Bigstring.t -> off:int -> len:int -> int
+val read : t -> Bigstringaf.t -> off:int -> len:int -> int
 val report_write_result : t -> [`Ok of int | `Closed ] -> unit
 
 val yield_reader : t -> (unit -> unit) -> unit

--- a/lib/client_websocket.mli
+++ b/lib/client_websocket.mli
@@ -3,20 +3,20 @@ module IOVec = Httpaf.IOVec
 type t
 
 type input_handlers =
-  { frame : Websocket.Opcode.t -> is_fin:bool -> Bigstringaf.t -> off:int -> len:int -> unit
-  ; eof   : unit                                                                   -> unit }
+  { frame : opcode:Websocket.Opcode.t -> is_fin:bool -> Bigstringaf.t -> off:int -> len:int -> unit
+  ; eof   : unit                                                                          -> unit }
 
-val create 
+val create
   :  websocket_handler : (Wsd.t -> input_handlers)
   -> t
 
-val next_read_operation  : t -> [ `Read | `Yield | `Close ]
+val next_read_operation  : t -> [ `Read | `Close ]
 val next_write_operation : t -> [ `Write of Bigstringaf.t IOVec.t list | `Yield | `Close of int ]
 
 val read : t -> Bigstringaf.t -> off:int -> len:int -> int
+val read_eof : t -> Bigstringaf.t -> off:int -> len:int -> int
 val report_write_result : t -> [`Ok of int | `Closed ] -> unit
 
-val yield_reader : t -> (unit -> unit) -> unit
 val yield_writer : t -> (unit -> unit) -> unit
 
 val close : t -> unit

--- a/lib/reader.ml
+++ b/lib/reader.ml
@@ -3,31 +3,34 @@ module AU = Angstrom.Unbuffered
 type 'error parse_state =
   | Done
   | Fail    of 'error
-  | Partial of (Bigstringaf.t -> off:int -> len:int -> AU.more -> (unit, 'error) result AU.state)
+  | Partial of (Bigstringaf.t -> off:int -> len:int -> AU.more -> unit AU.state)
 
 type 'error t =
   { parser : unit Angstrom.t
   ; mutable parse_state : 'error parse_state
   ; mutable closed      : bool }
 
-let create frame_handler  =
-  let open Angstrom in
-  Websocket.parser
-  >>| fun bs ->
-    let is_fin = Frame.is_fin bs in
-    let opcode = Frame.opcode bs in
-    Frame.unmask bs;
-    frame_handler ~is_fin ~opcode bs ~off ~len:(Bigstringaf.length bs)
+let create frame_handler =
+  let parser =
+    let open Angstrom in
+    Websocket.Frame.parse
+    >>| fun frame ->
+      let is_fin = Websocket.Frame.is_fin frame in
+      let opcode = Websocket.Frame.opcode frame in
+      Websocket.Frame.unmask frame;
+      Websocket.Frame.with_payload frame ~f:(frame_handler ~opcode ~is_fin)
+  in
+  { parser
+  ; parse_state = Done
+  ; closed      = false
+  }
 ;;
 
 let transition t state =
   match state with
-  | AU.Done(consumed, Ok ())
+  | AU.Done(consumed, ())
   | AU.Fail(0 as consumed, _, _) ->
     t.parse_state <- Done;
-    consumed
-  | AU.Done(consumed, Error error) ->
-    t.parse_state <- Fail error;
     consumed
   | AU.Fail(consumed, marks, msg) ->
     t.parse_state <- Fail (`Parse(marks, msg));
@@ -37,10 +40,37 @@ let transition t state =
     committed
 and start t state =
     match state with
-    | AU.Done _         -> failwith "httpaf.Parse.unable to start parser"
+    | AU.Done _         -> failwith "websocketaf.Reader.unable to start parser"
     | AU.Fail(0, marks, msg) ->
       t.parse_state <- Fail (`Parse(marks, msg))
     | AU.Partial { committed = 0; continue } ->
       t.parse_state <- Partial continue
     | _ -> assert false
+;;
+
+let next t =
+  match t.parse_state with
+  | Done ->
+    if t.closed
+    then `Close
+    else `Read
+  | Fail    _ -> `Close
+  | Partial _ -> `Read
+;;
+
+let rec read_with_more t bs ~off ~len more =
+  let consumed =
+    match t.parse_state with
+    | Fail _ -> 0
+    | Done   ->
+      start t (AU.parse t.parser);
+      read_with_more  t bs ~off ~len more;
+    | Partial continue ->
+      transition t (continue bs more ~off ~len)
+  in
+  begin match more with
+  | Complete -> t.closed <- true;
+  | Incomplete -> ()
+  end;
+  consumed
 ;;

--- a/lib/reader.ml
+++ b/lib/reader.ml
@@ -17,7 +17,7 @@ let create frame_handler =
     >>| fun frame ->
       let is_fin = Websocket.Frame.is_fin frame in
       let opcode = Websocket.Frame.opcode frame in
-      Websocket.Frame.unmask frame;
+      Websocket.Frame.unmask_inplace frame;
       Websocket.Frame.with_payload frame ~f:(frame_handler ~opcode ~is_fin)
   in
   { parser

--- a/lib/reader.ml
+++ b/lib/reader.ml
@@ -3,7 +3,7 @@ module AU = Angstrom.Unbuffered
 type 'error parse_state =
   | Done
   | Fail    of 'error
-  | Partial of (Bigstring.t -> off:int -> len:int -> AU.more -> (unit, 'error) result AU.state)
+  | Partial of (Bigstringaf.t -> off:int -> len:int -> AU.more -> (unit, 'error) result AU.state)
 
 type 'error t =
   { parser : unit Angstrom.t
@@ -17,7 +17,7 @@ let create frame_handler  =
     let is_fin = Frame.is_fin bs in
     let opcode = Frame.opcode bs in
     Frame.unmask bs;
-    frame_handler ~is_fin ~opcode bs ~off ~len:(Bigstring.length bs)
+    frame_handler ~is_fin ~opcode bs ~off ~len:(Bigstringaf.length bs)
 ;;
 
 let transition t state =

--- a/lib/websocket.ml
+++ b/lib/websocket.ml
@@ -235,10 +235,6 @@ module Frame = struct
     2 + payload_offset + payload_length 
   ;;
 
-  let length t =
-    length_of_offset t 0
-  ;;
-
   let apply_mask mask bs ~off ~len =
     for i = off to len - 1 do
       let j = (i - off) mod 4 in
@@ -258,7 +254,7 @@ module Frame = struct
   ;;
 
 
-  let unmask t =
+  let unmask_inplace t =
     if has_mask t then begin
       let mask = mask_exn t in
       let len = payload_length t in
@@ -267,7 +263,7 @@ module Frame = struct
     end
   ;;
 
-  let mask = unmask
+  let mask_inplace = unmask_inplace
 
   let parse =
     let open Angstrom in

--- a/lib/websocket.mli
+++ b/lib/websocket.mli
@@ -70,9 +70,9 @@ module Frame : sig
   val mask_exn : t -> int32
 
   val payload_length : t -> int
-  val with_payload   : t -> f:(Bigstring.t -> off:int -> len:int -> 'a) -> 'a
+  val with_payload   : t -> f:(Bigstringaf.t -> off:int -> len:int -> 'a) -> 'a
 
-  val copy_payload       : t -> Bigstring.t
+  val copy_payload       : t -> Bigstringaf.t
   val copy_payload_bytes : t -> Bytes.t
 
   val parse : t Angstrom.t
@@ -84,7 +84,7 @@ module Frame : sig
     -> Faraday.t
     -> is_fin:bool 
     -> opcode:Opcode.t 
-    -> payload:Bigstring.t
+    -> payload:Bigstringaf.t
     -> off:int
     -> len:int
     -> Faraday.t

--- a/lib/websocket.mli
+++ b/lib/websocket.mli
@@ -77,7 +77,11 @@ module Frame : sig
 
   val parse : t Angstrom.t
 
-  val serialize_control : Faraday.t -> opcode:Opcode.standard_control -> unit
+  val serialize_control
+    : ?mask:int32
+    -> Faraday.t
+    -> opcode:Opcode.standard_control
+    -> unit
 
   val schedule_serialize 
     :  ?mask:int32
@@ -87,10 +91,19 @@ module Frame : sig
     -> payload:Bigstringaf.t
     -> off:int
     -> len:int
-    -> Faraday.t
     -> unit
 
   val schedule_serialize_bytes
+    :  ?mask:int32
+    -> Faraday.t
+    -> is_fin:bool
+    -> opcode:Opcode.t
+    -> payload:Bytes.t
+    -> off:int
+    -> len:int
+    -> unit
+
+  val serialize_bytes
     :  ?mask:int32
     -> Faraday.t
     -> is_fin:bool 

--- a/lib/websocket.mli
+++ b/lib/websocket.mli
@@ -69,6 +69,9 @@ module Frame : sig
   val mask     : t -> int32 option
   val mask_exn : t -> int32
 
+  val mask_inplace   : t -> unit
+  val unmask_inplace : t -> unit
+
   val payload_length : t -> int
   val with_payload   : t -> f:(Bigstringaf.t -> off:int -> len:int -> 'a) -> 'a
 

--- a/lib/wsd.ml
+++ b/lib/wsd.ml
@@ -1,20 +1,76 @@
-type t = Faraday.t
+module IOVec = Httpaf.IOVec
 
-let schedule ?mask t ~kind payload ~off ~len =
-  Websocket.Frame.schedule_serialize ?mask t ~is_fin:true ~opcode:kind ~payload ~off ~len
+type mode =
+  [ `Client of unit -> int32
+  | `Server
+  ]
 
-let send_bytes ?mask t ~kind payload ~off ~len =
-  Websocket.Frame.schedule_serialize_bytes ?mask t ~is_fin:true ~opcode:kind ~payload ~off ~len
+type t =
+  { faraday : Faraday.t
+  ; mode : mode
+  ; mutable when_ready_to_write : unit -> unit
+  }
+
+let default_ready_to_write = Sys.opaque_identity (fun () -> ())
+
+let create mode =
+  { faraday = Faraday.create 0x1000
+  ; mode
+  ; when_ready_to_write = default_ready_to_write;
+  }
+
+let mask t =
+  match t.mode with
+  | `Client m -> Some (m ())
+  | `Server -> None
+
+let ready_to_write t =
+  let callback = t.when_ready_to_write in
+  t.when_ready_to_write <- default_ready_to_write;
+  callback ()
+
+let schedule t ~kind payload ~off ~len =
+  let mask = mask t in
+  Websocket.Frame.schedule_serialize t.faraday ?mask ~is_fin:true ~opcode:(kind :> Websocket.Opcode.t) ~payload ~off ~len;
+  ready_to_write t
+
+let send_bytes t ~kind payload ~off ~len =
+  let mask = mask t in
+  Websocket.Frame.schedule_serialize_bytes t.faraday ?mask ~is_fin:true ~opcode:(kind :> Websocket.Opcode.t) ~payload ~off ~len;
+  ready_to_write t
 
 let send_ping t =
-  Websocket.Frame.serialize_control t ~opcode:`Ping
+  Websocket.Frame.serialize_control t.faraday ~opcode:`Ping;
+  ready_to_write t
 
 let send_pong t =
-  Websocket.Frame.serialize_control t ~opcode:`Pong
+  Websocket.Frame.serialize_control t.faraday ~opcode:`Pong;
+  ready_to_write t
 
-let flushed t f = Faraday.flush t f
+let flushed t f = Faraday.flush t.faraday f
 
 let close t =
-  Websocket.Frame.serialize_control t ~opcode:`Connection_close;
-  Faraday.close t
-;;
+  Websocket.Frame.serialize_control t.faraday ~opcode:`Connection_close;
+  Faraday.close t.faraday;
+  ready_to_write t
+
+let next t =
+  match Faraday.operation t.faraday with
+  | `Close         -> `Close 0 (* XXX(andreas): should track unwritten bytes *)
+  | `Yield         -> `Yield
+  | `Writev iovecs -> `Write iovecs
+
+let report_result t result =
+  match result with
+  | `Closed -> close t
+  | `Ok len -> Faraday.shift t.faraday len
+
+let is_closed t =
+  Faraday.is_closed t.faraday
+
+let when_ready_to_write t callback =
+  if not (t.when_ready_to_write == default_ready_to_write)
+  then failwith "Wsd.when_ready_to_write: only one callback can be registered at a time"
+  else if is_closed t
+  then callback ()
+  else t.when_ready_to_write <- callback

--- a/lib/wsd.mli
+++ b/lib/wsd.mli
@@ -1,8 +1,18 @@
+module IOVec = Httpaf.IOVec
+
+type mode =
+  [ `Client of unit -> int32
+  | `Server
+  ]
+
 type t 
 
-val schedule
-  :  ?mask:int32
+val create
+  : mode
   -> t
+
+val schedule
+  :  t
   -> kind:[ `Text | `Binary ]
   -> Bigstringaf.t
   -> off:int
@@ -10,8 +20,7 @@ val schedule
   -> unit
 
 val send_bytes
-  :  ?mask:int32
-  -> t
+  :  t
   -> kind:[ `Text | `Binary ]
   -> Bytes.t
   -> off:int
@@ -23,3 +32,10 @@ val send_pong : t -> unit
 
 val flushed : t -> (unit -> unit) -> unit
 val close   : t -> unit
+
+val next : t -> [ `Write of Bigstringaf.t IOVec.t list | `Yield | `Close of int ]
+val report_result : t -> [`Ok of int | `Closed ] -> unit
+
+val is_closed : t -> bool
+
+val when_ready_to_write : t -> (unit -> unit) -> unit

--- a/lib/wsd.mli
+++ b/lib/wsd.mli
@@ -4,7 +4,7 @@ val schedule
   :  ?mask:int32
   -> t
   -> kind:[ `Text | `Binary ]
-  -> Bigstring.t
+  -> Bigstringaf.t
   -> off:int
   -> len:int
   -> unit

--- a/websocketaf.opam
+++ b/websocketaf.opam
@@ -1,25 +1,25 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
 authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
 license: "BSD-3-clause"
 homepage: "https://github.com/inhabitedtype/websocketaf"
 bug-reports: "https://github.com/inhabitedtype/websocketaf/issues"
-dev-repo: "https://github.com/inhabitedtype/websocketaf.git"
+dev-repo: "git+https://github.com/inhabitedtype/websocketaf.git"
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-]
-build-test: [
-  ["dune" "runtest" "-p" name]
+  ["dune" "runtest" "-p" name] {with-test}
 ]
 depends: [
+  "ocaml" {>= "4.03.0"}
   "dune" {build}
   "base64"   {>= "3.0.0"}
-  "alcotest" {test}
+  "alcotest" {with-test}
   "bigstringaf"
   "angstrom" {>= "0.7.0"}
   "faraday"  {>= "0.5.0"}
   "httpaf"
   "result"
 ]
-available: [ ocaml-version >= "4.03.0" ]
+synopsis:
+  "Websocket implementation for use with http/af"

--- a/websocketaf.opam
+++ b/websocketaf.opam
@@ -14,7 +14,7 @@ build-test: [
 ]
 depends: [
   "dune" {build}
-  "base64"
+  "base64"   {>= "3.0.0"}
   "alcotest" {test}
   "bigstringaf"
   "angstrom" {>= "0.7.0"}


### PR DESCRIPTION
Cherry-pick some build fixes from #1, provided by @andreas. Finish the port over to `bigstringaf`, which was previously difficult to do due to unrelated build errors. Add a lower-bound on `base64` and perform the appropriate renames. Finally, fix OPAM linting errors.