### PR TITLE
httpaf-bounds: Add an upper bound to httpaf dependency

### DIFF
--- a/websocketaf.opam
+++ b/websocketaf.opam
@@ -18,7 +18,7 @@ depends: [
   "bigstringaf"
   "angstrom" {>= "0.7.0"}
   "faraday"  {>= "0.5.0"}
-  "httpaf"
+  "httpaf"   {<  "0.6.0"}
   "result"
 ]
 synopsis:


### PR DESCRIPTION
The next release of httpaf will likey break what's currently in master.